### PR TITLE
feat: support for the new escaping tag function "e" and "escape"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "self": "file:."
   },
   "peerDependencies": {
-    "@kitajs/html": "^3.0.10",
+    "@kitajs/html": "^3.1.1",
     "typescript": "^5.2.2"
   },
   "packageManager": "pnpm@8.7.5"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "format": "prettier --write .",
     "prepack": "npm run build",
-    "test": "node --require @swc-node/register --test test/**/*.test.ts"
+    "test": "node --require @swc-node/register --test test/**/*.test.ts",
+    "test-procedure": "pnpm build && pnpm install && pnpm test"
   },
   "dependencies": {
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@kitajs/html':
-    specifier: ^3.0.10
-    version: 3.0.10(@kitajs/ts-html-plugin@1.3.0)
+    specifier: ^3.1.1
+    version: 3.1.1(@kitajs/ts-html-plugin@1.3.3)
   chalk:
     specifier: ^4.1.2
     version: 4.1.2
@@ -45,7 +45,7 @@ devDependencies:
     version: 3.2.4
   self:
     specifier: file:.
-    version: file:(@kitajs/html@3.0.10)(typescript@5.2.2)
+    version: file:(@kitajs/html@3.1.1)(typescript@5.2.2)
 
 packages:
 
@@ -66,23 +66,23 @@ packages:
       - typescript
     dev: true
 
-  /@kitajs/html@3.0.10(@kitajs/ts-html-plugin@1.3.0):
-    resolution: {integrity: sha512-3SblgDWCJOVrXFTf5dciXF3sj96CazDfHteuXHX8OHibjdYAmyLj3j0+s3y6B0ppcICR4x0i90CkkOvk2q+M7Q==}
+  /@kitajs/html@3.1.1(@kitajs/ts-html-plugin@1.3.3):
+    resolution: {integrity: sha512-tm7Vgb6ItXevyGYZC3ycikPN2wslVVCpPcO1o9W9rf20aGrUsn3/GxBbTbu7MIqNLVJ5L+5XMxyfUSIP41lMZA==}
     engines: {node: '>=12'}
     peerDependencies:
-      '@kitajs/ts-html-plugin': '>=1.2.0'
+      '@kitajs/ts-html-plugin': '>=1.3.3'
     dependencies:
-      '@kitajs/ts-html-plugin': 1.3.0(@kitajs/html@3.0.10)(typescript@5.2.2)
-      csstype: 3.1.2
+      '@kitajs/ts-html-plugin': 1.3.3(@kitajs/html@3.1.1)(typescript@5.2.2)
+      csstype: 3.1.3
 
-  /@kitajs/ts-html-plugin@1.3.0(@kitajs/html@3.0.10)(typescript@5.2.2):
-    resolution: {integrity: sha512-1zrx+bNtP6Sh/mDklnkGuGcPF2hjJpiR7pwWm7HormmMHYvk8zUFQnAA0XWqrVwWW9g/q+WGxqHRPxxEprbooA==}
+  /@kitajs/ts-html-plugin@1.3.3(@kitajs/html@3.1.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-qam/xc4zgP9e/CeSlBcpmJ5BOf9jCUr7qee6KcxzuFXN8fFf8IeNph46ukrQCXk0tEiItd48BnkkL0jEAozdeg==}
     hasBin: true
     peerDependencies:
-      '@kitajs/html': '>=3'
-      typescript: '>=5'
+      '@kitajs/html': ^3.0.10
+      typescript: ^5.2.2
     dependencies:
-      '@kitajs/html': 3.0.10(@kitajs/ts-html-plugin@1.3.0)
+      '@kitajs/html': 3.1.1(@kitajs/ts-html-plugin@1.3.3)
       chalk: 4.1.2
       tslib: 2.6.2
       typescript: 5.2.2
@@ -411,8 +411,8 @@ packages:
       which: 2.0.2
     dev: true
 
-  /csstype@3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1203,16 +1203,16 @@ packages:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  file:(@kitajs/html@3.0.10)(typescript@5.2.2):
+  file:(@kitajs/html@3.1.1)(typescript@5.2.2):
     resolution: {directory: '', type: directory}
     id: 'file:'
     name: '@kitajs/ts-html-plugin'
     hasBin: true
     peerDependencies:
-      '@kitajs/html': ^3.0.10
+      '@kitajs/html': ^3.1.1
       typescript: ^5.2.2
     dependencies:
-      '@kitajs/html': 3.0.10(@kitajs/ts-html-plugin@1.3.0)
+      '@kitajs/html': 3.1.1(@kitajs/ts-html-plugin@1.3.3)
       chalk: 4.1.2
       tslib: 2.6.2
       typescript: 5.2.2

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ import type {
 import * as Errors from './errors';
 
 const UPPERCASE = /[A-Z]/;
-const ESCAPE_HTML_REGEX = /^(\w+\.)?escapeHtml/i;
+const ESCAPE_HTML_REGEX = /^(\w+\.)?(escapeHtml|e|escape)/i;
 
 /** If the node is a JSX element or fragment */
 export function isJsx(ts: typeof TS, node: TS.Node): node is JsxElement | JsxFragment {

--- a/test/component-xss.test.ts
+++ b/test/component-xss.test.ts
@@ -55,3 +55,56 @@ it('Ensure <Component /> children are safe', async () => {
     }
   ]);
 });
+
+it('Ensure <Component /> children are safe using "e" tag function', async () => {
+  await using server = new TSLangServer(__dirname);
+
+  const diagnostics = await server.openWithDiagnostics/* tsx */ `
+    export default (
+      <>
+        {/* error */}
+        <div>
+        {['a', 'b', 'c'].map((i) => (
+          <Component>{i}</Component>
+        ))}
+        </div>
+        <Component>
+          {['a', 'b', 'c'].map((i) => (i === 'a' ? safeString : <Component>{i}</Component>))}
+        </Component>
+
+        {/* safe */}
+        <div>
+          {[1, 2, 3].map((i) => (
+            <Component>{i}</Component>
+          ))}
+        </div>
+        <div>
+          {['a', 'b', 'c'].map((i) => (
+            ${'<Component>{Html.e`${i}`}</Component>'}
+          ))}
+        </div>
+        <div>
+          ${'<Component>{Html.e`${object}`}</Component>'}
+          asd
+        </div>
+      </>
+    );
+`;
+
+  assert.deepStrictEqual(diagnostics.body, [
+    {
+      start: { line: 39, offset: 23 },
+      end: { line: 39, offset: 24 },
+      text: ComponentXss.message,
+      code: ComponentXss.code,
+      category: 'error'
+    },
+    {
+      start: { line: 43, offset: 77 },
+      end: { line: 43, offset: 78 },
+      text: ComponentXss.message,
+      code: ComponentXss.code,
+      category: 'error'
+    }
+  ]);
+});

--- a/test/component-xss.test.ts
+++ b/test/component-xss.test.ts
@@ -87,6 +87,15 @@ it('Ensure <Component /> children are safe using "e" tag function', async () => 
           ${'<Component>{Html.e`${object}`}</Component>'}
           asd
         </div>
+        <div>
+          {['a', 'b', 'c'].map((i) => (
+            ${'<Component>{e`${i}`}</Component>'}
+          ))}
+        </div>
+        <div>
+          ${'<Component>{e`${object}`}</Component>'}
+          asd
+        </div>
       </>
     );
 `;

--- a/test/double-escape.test.ts
+++ b/test/double-escape.test.ts
@@ -18,6 +18,7 @@ it('Avoid escaping twice', async () => {
         </div>
         <div safe>{Html.escapeHtml(object)}</div>
         ${'<div safe>{Html.e`${object}`}</div>'}
+        ${'<div safe>{e`${object}`}</div>'}
       </>
     );
 `;
@@ -47,6 +48,13 @@ it('Avoid escaping twice', async () => {
     {
       start: { line: 44, offset: 14 },
       end: { line: 44, offset: 18 },
+      text: DoubleEscape.message,
+      code: DoubleEscape.code,
+      category: 'error'
+    },
+    {
+      start: { line: 45, offset: 14 },
+      end: { line: 45, offset: 18 },
       text: DoubleEscape.message,
       code: DoubleEscape.code,
       category: 'error'

--- a/test/double-escape.test.ts
+++ b/test/double-escape.test.ts
@@ -17,6 +17,7 @@ it('Avoid escaping twice', async () => {
           asd
         </div>
         <div safe>{Html.escapeHtml(object)}</div>
+        ${'<div safe>{Html.e`${object}`}</div>'}
       </>
     );
 `;
@@ -39,6 +40,13 @@ it('Avoid escaping twice', async () => {
     {
       start: { line: 43, offset: 14 },
       end: { line: 43, offset: 18 },
+      text: DoubleEscape.message,
+      code: DoubleEscape.code,
+      category: 'error'
+    },
+    {
+      start: { line: 44, offset: 14 },
+      end: { line: 44, offset: 18 },
       text: DoubleEscape.message,
       code: DoubleEscape.code,
       category: 'error'

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -14,16 +14,13 @@ it('Ensures readme checks will throw error', async () => {
     );
 `;
 
-  assert.deepStrictEqual(
-    diagnostics.body,
-    [
-      {
-        category: 'error',
-        code: Xss.code,
-        end: { line: 36, offset: 26 },
-        start: { line: 36, offset: 15 },
-        text: Xss.message
-      }
-    ]
-  );
+  assert.deepStrictEqual(diagnostics.body, [
+    {
+      category: 'error',
+      code: Xss.code,
+      end: { line: 36, offset: 26 },
+      start: { line: 36, offset: 15 },
+      text: Xss.message
+    }
+  ]);
 });

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -26,6 +26,16 @@ it('Allow correct xss usage', async () => {
           ))}
         </div>
         <div>
+          {['asda', 'b', 'c'].map((i) => (
+            ${'<>{Html.e`${i} some text`}</>'}
+          ))}
+        </div>
+        <div>
+        {['asda', 'b', 'c'].map((i) => (
+          ${'<>{Html.escape`${i} some text`}</>'}
+        ))}
+      </div>
+        <div>
           {['a', 'b', 'c'].map((i) => (
             <div safe>{i}</div>
           ))}
@@ -43,6 +53,10 @@ it('Allow correct xss usage', async () => {
         </div>
         <div>{Html.escapeHtml(html)}</div>
         <div>{Html.escapeHtml(object)}</div>
+        ${'<div>{Html.e`${html}`}</div>'}
+        ${'<div>{Html.e`${object}`}</div>'}
+        ${'<div>{Html.escape`${html}`}</div>'}
+        ${'<div>{Html.escape`${object}`}</div>'}
         <div>{boolean ? number : safeString}</div>
         <div>{number || safeString}</div>
       </>

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -31,10 +31,10 @@ it('Allow correct xss usage', async () => {
           ))}
         </div>
         <div>
-        {['asda', 'b', 'c'].map((i) => (
-          ${'<>{Html.escape`${i} some text`}</>'}
-        ))}
-      </div>
+          {['asda', 'b', 'c'].map((i) => (
+            ${'<>{Html.escape`${i} some text`}</>'}
+          ))}
+        </div>
         <div>
           {['a', 'b', 'c'].map((i) => (
             <div safe>{i}</div>
@@ -55,6 +55,8 @@ it('Allow correct xss usage', async () => {
         <div>{Html.escapeHtml(object)}</div>
         ${'<div>{Html.e`${html}`}</div>'}
         ${'<div>{Html.e`${object}`}</div>'}
+        ${'<div>{e`${html}`}</div>'}
+        ${'<div>{e`${object}`}</div>'}
         ${'<div>{Html.escape`${html}`}</div>'}
         ${'<div>{Html.escape`${object}`}</div>'}
         <div>{boolean ? number : safeString}</div>

--- a/test/util/lang-server.ts
+++ b/test/util/lang-server.ts
@@ -20,7 +20,7 @@ const TEST_FILE = path.join(__dirname, 'index.tsx');
 const ROOT = path.join(__dirname, '..');
 
 export const TEST_HELPERS = /* tsx */ `
-  import Html, { PropsWithChildren } from '@kitajs/html';
+  import Html, { PropsWithChildren, e } from '@kitajs/html';
 
   const date = new Date();
   const safeString: string = 'safe';
@@ -40,7 +40,7 @@ export const TEST_HELPERS = /* tsx */ `
   // just to avoid unused variable error
   if (process.env.NEVER) {
     console.log({
-      date,
+      date, e
       safeString,
       promiseHtml,
       promiseNumber,


### PR DESCRIPTION
This PR is related to [this PR](https://github.com/kitajs/html/pull/112)

I've encountered an issue running the tests locally because you had to build the lib and then run the pnpm install command again to make it so that there is the `self` package. I've added a script in the package.json that streamlines this process.

I've added a couple of tests but now they are all failing because the main package ([kitajs/html](https://github.com/kitajs/html)) does not have a function called `e`. Locally I've linked the new version and the tests passed but that could be an issue for someone who wants to contribute. @arthurfiorette did you ever consider moving all these projects into a single mono-repo? That would solve those kinds of problems.

Anyway, this is the adaptation to make the plugin work with the new escaping tag function API.
Hope I've helped.