### PR TITLE
update vscode settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ current project's typescript version.
 // .vscode/settings.json
 
 {
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.tsdk": "node_modules/typescript/lib"
 }
 ```


### PR DESCRIPTION
Added `"typescript.enablePromptUseWorkspaceTsdk": true` inside `.vscode/settings.json` in README. If `enablePromptUseWorkspaceTsdk` is not enabled in VSCode User settings then tsdk path inside workspace settings will be ignored.
<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
